### PR TITLE
Update register.php

### DIFF
--- a/register.php
+++ b/register.php
@@ -20,9 +20,9 @@
                     if(!empty($_POST))
                     {
                         // includes
-                        include("inc/settings.inc.php");
-                        include("inc/database.inc.php");
-                        include("inc/user.inc.php");
+                        require_once "inc/settings.inc.php";
+                        require_once "inc/database.inc.php";
+                        require_once "inc/user.inc.php";
 
                         // variables
                         $database = new Database();


### PR DESCRIPTION
Changed `include()` to `require_once` because you only need to load them in once. Also removed the () because `include` and `require` are statements, not functions. `require` throws an exception which kills the page which is smarter when you're loading important files, where include only shows you a warning. You don't want to keep loading the page if the database, user and settings can't be loaded.